### PR TITLE
Solves warning about uncertain initialisation

### DIFF
--- a/examples/tcs34725autorange/tcs34725autorange.ino
+++ b/examples/tcs34725autorange/tcs34725autorange.ino
@@ -135,7 +135,7 @@ void tcs34725::getData(void) {
   cratio = float(ir) / float(c);
 
   saturation = ((256 - atime) > 63) ? 65535 : 1024 * (256 - atime);
-  saturation75 = (atime_ms < 150) ? saturation75 = saturation - saturation / 4 : saturation;
+  saturation75 = (atime_ms < 150) ? (saturation - saturation / 4) : saturation;
   isSaturated = (atime_ms < 150 && c > saturation75) ? 1 : 0;
   cpl = (atime_ms * againx) / (TCS34725_GA * TCS34725_DF); 
   maxlux = 65535 / (cpl * 3);


### PR DESCRIPTION
The assignment of the variable was typed twice in the ternary conditional operator and this causes the compiler to warn about potential missing initialisation.