### PR TITLE
Removing Serial reference from .cpp file.

### DIFF
--- a/Adafruit_TCS34725.cpp
+++ b/Adafruit_TCS34725.cpp
@@ -167,7 +167,6 @@ boolean Adafruit_TCS34725::begin(void)
   
   /* Make sure we're actually connected */
   uint8_t x = read8(TCS34725_ID);
-  Serial.println(x, HEX);
   if ((x != 0x44) && (x != 0x10))
   {
     return false;


### PR DESCRIPTION
Libraries should not reference Serial as it could be in use for other purposes and/or can cause unexpected behavior when in use on other devices or platforms! :)