### PR TITLE
The splits had to be done for spaces, instead of tabs

### DIFF
--- a/examples/colorview/processing/colorview/colorview.pde
+++ b/examples/colorview/processing/colorview/colorview.pde
@@ -11,8 +11,8 @@ import java.awt.Toolkit;
 Serial port;
  
 void setup(){
- size(200,200);
- port = new Serial(this, "COM4", 9600); //remember to replace COM20 with the appropriate serial port on your computer
+ size(500,500);
+ port = new Serial(this, "/dev/cu.usbmodem1411", 9600); // Remember to enter the correct serial port on your computer, something like "/dev/cu.usbmodem1411"
 }
  
  
@@ -34,12 +34,12 @@ void serialEvent(int serial) {
  if(serial != '\n') {
    buff += char(serial);
  } else {
-   //println(buff);
+   println(buff);
    
-   int cRed = buff.indexOf("R");
-   int cGreen = buff.indexOf("G");
-   int cBlue = buff.indexOf("B");
-   int clear = buff.indexOf("C");
+   int cRed = buff.indexOf("R:");
+   int cGreen = buff.indexOf("G:");
+   int cBlue = buff.indexOf("B:");
+   int clear = buff.indexOf("C:");
    if(clear >=0){
      String val = buff.substring(clear+3);
      val = val.split("\t")[0]; 
@@ -48,19 +48,19 @@ void serialEvent(int serial) {
    
    if(cRed >=0){
      String val = buff.substring(cRed+3);
-     val = val.split("\t")[0]; 
+     val = val.split(" ")[0]; 
      wRed = Integer.parseInt(val.trim());
    } else { return; }
    
    if(cGreen >=0) {
      String val = buff.substring(cGreen+3);
-     val = val.split("\t")[0]; 
+     val = val.split(" ")[0]; 
      wGreen = Integer.parseInt(val.trim());
    } else { return; }
    
    if(cBlue >=0) {
      String val = buff.substring(cBlue+3);
-     val = val.split("\t")[0]; 
+     val = val.split(" ")[0]; 
      wBlue = Integer.parseInt(val.trim());
    } else { return; }
    


### PR DESCRIPTION
This example had to be updated to work by splitting the R, G, B and Clear values after `R:`, `G:`, `B:` , `:C` and `spaces`

E.g, on an entry `Color Temp: 6017 K - Lux: 46790 - R: 37924 G: 57575 B: 43410 C: 65535`, splitting on `\t` and taking its `[0]` element was incorrectly producing  `olor Temp: 6017 K - Lux: 46790 - R: 37924 G: 57575 B: 43410 C: 65535`. These was not the desired results

By splitting on `R:` and `space`, it selects the correct value `37924`, and splitting on `C:` and `space` produces `65535`
