### PR TITLE
Enable Low Power Mode Through the Use of Disable State

### DIFF
--- a/Adafruit_TCS34725.cpp
+++ b/Adafruit_TCS34725.cpp
@@ -282,6 +282,21 @@ void Adafruit_TCS34725::getRawData (uint16_t *r, uint16_t *g, uint16_t *b, uint1
 
 /**************************************************************************/
 /*!
+    @brief  Reads the raw red, green, blue and clear channel values in
+    one-shot mode (e.g., wakes from sleep, takes measurement, enters sleep)
+*/
+/**************************************************************************/
+void Adafruit_TCS34725::getRawDataOneShot (uint16_t *r, uint16_t *g, uint16_t *b, uint16_t *c)
+{
+  if (!_tcs34725Initialised) begin();
+
+  enable();
+  getRawData(r, g, b ,c);
+  disable();
+}
+
+/**************************************************************************/
+/*!
     @brief  Converts the raw R/G/B values to color temperature in degrees
             Kelvin
 */

--- a/Adafruit_TCS34725.cpp
+++ b/Adafruit_TCS34725.cpp
@@ -120,6 +120,33 @@ void Adafruit_TCS34725::enable(void)
   write8(TCS34725_ENABLE, TCS34725_ENABLE_PON);
   delay(3);
   write8(TCS34725_ENABLE, TCS34725_ENABLE_PON | TCS34725_ENABLE_AEN);  
+    /* Set a delay for the integration time.
+      This is only necessary in the case where enabling and then 
+      immediately trying to read values back. This is because setting
+      AEN triggers an automatic integration, so if a read RGBC is
+      performed too quickly, the data is not yet valid and all 0's are
+      returned */
+  switch (_tcs34725IntegrationTime)
+  {
+    case TCS34725_INTEGRATIONTIME_2_4MS:
+      delay(3);
+      break;
+    case TCS34725_INTEGRATIONTIME_24MS:
+      delay(24);
+      break;
+    case TCS34725_INTEGRATIONTIME_50MS:
+      delay(50);
+      break;
+    case TCS34725_INTEGRATIONTIME_101MS:
+      delay(101);
+      break;
+    case TCS34725_INTEGRATIONTIME_154MS:
+      delay(154);
+      break;
+    case TCS34725_INTEGRATIONTIME_700MS:
+      delay(700);
+      break;
+  }
 }
 
 /**************************************************************************/

--- a/Adafruit_TCS34725.h
+++ b/Adafruit_TCS34725.h
@@ -132,13 +132,13 @@ class Adafruit_TCS34725 {
   void clearInterrupt(void);
   void setIntLimits(uint16_t l, uint16_t h);
   void     enable(void);
+  void     disable(void);
 
  private:
   boolean _tcs34725Initialised;
   tcs34725Gain_t _tcs34725Gain;
   tcs34725IntegrationTime_t _tcs34725IntegrationTime; 
   
-  void     disable(void);
 };
 
 #endif

--- a/Adafruit_TCS34725.h
+++ b/Adafruit_TCS34725.h
@@ -123,6 +123,7 @@ class Adafruit_TCS34725 {
   void     setIntegrationTime(tcs34725IntegrationTime_t it);
   void     setGain(tcs34725Gain_t gain);
   void     getRawData(uint16_t *r, uint16_t *g, uint16_t *b, uint16_t *c);
+  void     getRawDataOneShot(uint16_t *r, uint16_t *g, uint16_t *b, uint16_t *c);
   uint16_t calculateColorTemperature(uint16_t r, uint16_t g, uint16_t b);
   uint16_t calculateLux(uint16_t r, uint16_t g, uint16_t b);
   void     write8 (uint8_t reg, uint32_t value);


### PR DESCRIPTION
**SUMMARY OF NEED**
Since the disable functionality of this sensor is not available through the master code, using this on a battery powered device has poor performance. The sleep state has a current consumption of 10 uA typ whereas the active state (the state used when wait enable is not used, which is the default behavior) is 235 uA typ. By enabling the low power functionality, the current consumption can be reduced by **95%**, thus enabling extended battery operation.
![image](https://user-images.githubusercontent.com/3453241/48298996-b8f96180-e483-11e8-83d3-c99751fd174a.png)

**SUMMARY OF CHANGES**
The only real changes were 
1. Making the disable method public
2. Updating the enable method so that there is a delay for integration time after setting the PON and AEN bits. This is only necessary in the case of enabling and then immediately trying to take a reading. This is because setting the AEN bit triggers an automatic integration, so if a read RGBC is performed too quickly, the data is not yet valid and all 0's are returned.
3. Added oneshot read mode so that energy efficient single point measurements can be taken.