### PR TITLE
Fix for 'Division by Null' exception and compiler warnings

### DIFF
--- a/Adafruit_TCS34725.cpp
+++ b/Adafruit_TCS34725.cpp
@@ -74,7 +74,7 @@ uint8_t Adafruit_TCS34725::read8(uint8_t reg) {
 #endif
   _wire->endTransmission();
 
-  _wire->requestFrom(_i2caddr, 1);
+  _wire->requestFrom(_i2caddr, (uint8_t)1);
 #if ARDUINO >= 100
   return _wire->read();
 #else
@@ -99,7 +99,7 @@ uint16_t Adafruit_TCS34725::read16(uint8_t reg) {
 #endif
   _wire->endTransmission();
 
-  _wire->requestFrom(_i2caddr, 2);
+  _wire->requestFrom(_i2caddr, (uint8_t)2);
 #if ARDUINO >= 100
   t = _wire->read();
   x = _wire->read();
@@ -375,6 +375,10 @@ uint16_t Adafruit_TCS34725::calculateColorTemperature(uint16_t r, uint16_t g,
   float n;       /* McCamy's formula            */
   float cct;
 
+  if (r == 0 && g == 0 && b == 0) {
+    return 0;
+  }
+
   /* 1. Map RGB values to their XYZ counterparts.    */
   /* Based on 6500K fluorescent, 3000K fluorescent   */
   /* and 60W incandescent values for a wide range.   */
@@ -415,12 +419,13 @@ uint16_t Adafruit_TCS34725::calculateColorTemperature_dn40(uint16_t r,
                                                            uint16_t g,
                                                            uint16_t b,
                                                            uint16_t c) {
-  int rc;              /* Error return code */
-  uint16_t r2, g2, b2; /* RGB values minus IR component */
-  int gl;              /* Results of the initial lux conversion */
-  uint8_t gain_int;    /* Gain multiplier as a normal integer */
+  uint16_t r2, b2; /* RGB values minus IR component */
   uint16_t sat;        /* Digital saturation level */
   uint16_t ir;         /* Inferred IR content */
+
+  if (c == 0) {
+    return 0;
+  }
 
   /* Analog/Digital saturation:
    *
@@ -475,59 +480,7 @@ uint16_t Adafruit_TCS34725::calculateColorTemperature_dn40(uint16_t r,
 
   /* Remove the IR component from the raw RGB values */
   r2 = r - ir;
-  g2 = g - ir;
   b2 = b - ir;
-
-  /* Convert gain to a usable integer value */
-  switch (_tcs34725Gain) {
-  case TCS34725_GAIN_4X: /* GAIN 4X */
-    gain_int = 4;
-    break;
-  case TCS34725_GAIN_16X: /* GAIN 16X */
-    gain_int = 16;
-    break;
-  case TCS34725_GAIN_60X: /* GAIN 60X */
-    gain_int = 60;
-    break;
-  case TCS34725_GAIN_1X: /* GAIN 1X */
-  default:
-    gain_int = 1;
-    break;
-  }
-
-  /* Calculate the counts per lux (CPL), taking into account the optional
-   * arguments for Glass Attenuation (GA) and Device Factor (DF).
-   *
-   * GA = 1/T where T is glass transmissivity, meaning if glass is 50%
-   * transmissive, the GA is 2 (1/0.5=2), and if the glass attenuates light
-   * 95% the GA is 20 (1/0.05). A GA of 1.0 assumes perfect transmission.
-   *
-   * NOTE: It is recommended to have a CPL > 5 to have a lux accuracy
-   *       < +/- 0.5 lux, where the digitization error can be calculated via:
-   *       'DER = (+/-2) / CPL'.
-   */
-  float cpl =
-      (((256 - _tcs34725IntegrationTime) * 2.4f) * gain_int) / (1.0f * 310.0f);
-
-  /* Determine lux accuracy (+/- lux) */
-  float der = 2.0f / cpl;
-
-  /* Determine the maximum lux value */
-  float max_lux = 65535.0 / (cpl * 3);
-
-  /* Lux is a function of the IR-compensated RGB channels and the associated
-   * color coefficients, with G having a particularly heavy influence to
-   * match the nature of the human eye.
-   *
-   * NOTE: The green value should be > 10 to ensure the accuracy of the lux
-   *       conversions. If it is below 10, the gain should be increased, but
-   *       the clear<100 check earlier should cover this edge case.
-   */
-  gl = 0.136f * (float)r2 + /** Red coefficient. */
-       1.000f * (float)g2 + /** Green coefficient. */
-       -0.444f * (float)b2; /** Blue coefficient. */
-
-  float lux = gl / cpl;
 
   /* A simple method of measuring color temp is to use the ratio of blue */
   /* to red light, taking IR cancellation into account. */

--- a/Adafruit_TCS34725.cpp
+++ b/Adafruit_TCS34725.cpp
@@ -482,6 +482,10 @@ uint16_t Adafruit_TCS34725::calculateColorTemperature_dn40(uint16_t r,
   r2 = r - ir;
   b2 = b - ir;
 
+  if (r2 == 0) {
+    return 0;
+  }
+
   /* A simple method of measuring color temp is to use the ratio of blue */
   /* to red light, taking IR cancellation into account. */
   uint16_t cct = (3810 * (uint32_t)b2) / /** Color temp coefficient. */


### PR DESCRIPTION
This PR fixes two possible 'Division by Null' cases when the r,g,b values are null which happens if the sensor operates in darkness. See #30 
The `calculateColorTemperature` and `calculateColorTemperature_dn40` functions now return with zero.

In addition, I've fixed multiple compiler warnings and removed unused variables/code.


