### PR TITLE
Replace enum integration times with uint8_t.

### DIFF
--- a/Adafruit_TCS34725.cpp
+++ b/Adafruit_TCS34725.cpp
@@ -146,8 +146,7 @@ void Adafruit_TCS34725::disable() {
  *  @param  gain
  *          Gain
  */
-Adafruit_TCS34725::Adafruit_TCS34725(uint8_t it,
-                                     tcs34725Gain_t gain) {
+Adafruit_TCS34725::Adafruit_TCS34725(uint8_t it, tcs34725Gain_t gain) {
   _tcs34725Initialised = false;
   _tcs34725IntegrationTime = it;
   _tcs34725Gain = gain;

--- a/Adafruit_TCS34725.cpp
+++ b/Adafruit_TCS34725.cpp
@@ -146,7 +146,7 @@ void Adafruit_TCS34725::disable() {
  *  @param  gain
  *          Gain
  */
-Adafruit_TCS34725::Adafruit_TCS34725(tcs34725IntegrationTime_t it,
+Adafruit_TCS34725::Adafruit_TCS34725(uint8_t it,
                                      tcs34725Gain_t gain) {
   _tcs34725Initialised = false;
   _tcs34725IntegrationTime = it;
@@ -221,7 +221,7 @@ boolean Adafruit_TCS34725::init() {
  *  @param  it
  *          Integration Time
  */
-void Adafruit_TCS34725::setIntegrationTime(tcs34725IntegrationTime_t it) {
+void Adafruit_TCS34725::setIntegrationTime(uint8_t it) {
   if (!_tcs34725Initialised)
     begin();
 

--- a/Adafruit_TCS34725.cpp
+++ b/Adafruit_TCS34725.cpp
@@ -132,8 +132,8 @@ void Adafruit_TCS34725::enable() {
   case TCS34725_INTEGRATIONTIME_24MS:
     delay(24);
     break;
-  case TCS34725_INTEGRATIONTIME_50MS:
-    delay(50);
+  case TCS34725_INTEGRATIONTIME_48MS:
+    delay(48);
     break;
   case TCS34725_INTEGRATIONTIME_101MS:
     delay(101);
@@ -141,8 +141,8 @@ void Adafruit_TCS34725::enable() {
   case TCS34725_INTEGRATIONTIME_154MS:
     delay(154);
     break;
-  case TCS34725_INTEGRATIONTIME_700MS:
-    delay(700);
+  case TCS34725_INTEGRATIONTIME_615MS:
+    delay(615);
     break;
   }
 }
@@ -295,8 +295,8 @@ void Adafruit_TCS34725::getRawData(uint16_t *r, uint16_t *g, uint16_t *b,
   case TCS34725_INTEGRATIONTIME_24MS:
     delay(24);
     break;
-  case TCS34725_INTEGRATIONTIME_50MS:
-    delay(50);
+  case TCS34725_INTEGRATIONTIME_48MS:
+    delay(48);
     break;
   case TCS34725_INTEGRATIONTIME_101MS:
     delay(101);
@@ -304,8 +304,8 @@ void Adafruit_TCS34725::getRawData(uint16_t *r, uint16_t *g, uint16_t *b,
   case TCS34725_INTEGRATIONTIME_154MS:
     delay(154);
     break;
-  case TCS34725_INTEGRATIONTIME_700MS:
-    delay(700);
+  case TCS34725_INTEGRATIONTIME_615MS:
+    delay(615);
     break;
   }
 }

--- a/Adafruit_TCS34725.h
+++ b/Adafruit_TCS34725.h
@@ -138,14 +138,45 @@
 #define TCS34725_BDATAH (0x1B) /**< Blue channel data high byte */
 
 /** Integration time settings for TCS34725 */
+/* 100ms is evenly divisible by 50Hz periods and by 60Hz periods */
+// hex FF   cycles   1   integ 2.40   60Hz cycles 0.14   50Hz cycles 0.12
 #define TCS34725_INTEGRATIONTIME_2_4MS (0xFF)/* 2.4ms - 1 cycle - Max Count: 1024 */
+// hex F6   cycles  10   integ 24.00   60Hz cycles 1.44   50Hz cycles 1.20
 #define TCS34725_INTEGRATIONTIME_24MS (0xF6) /* 24ms - 10 cycles - Max Count: 10240 */
-#define TCS34725_INTEGRATIONTIME_48MS (0xEB) /* 48ms - 20 cycles - Max Count: 20480 */
-#define TCS34725_INTEGRATIONTIME_50MS (0xEB) /* WRONG BUT INCLUDED FOR LEGACY CODE */
-#define TCS34725_INTEGRATIONTIME_101MS (0xD5)/* 100.8ms - 42 cycles - Max Count: 43008 */
+// hex EB   cycles  21   integ 50.40   60Hz cycles 3.02   50Hz cycles 2.52
+#define TCS34725_INTEGRATIONTIME_50MS (0xEB) /* 50.4ms - 21 cycles - Max Count: ???? */
+// hex E7   cycles  25   integ 60.00   60Hz cycles 3.60   50Hz cycles 3.00
+#define TCS34725_INTEGRATIONTIME_60MS (0xE7)
+// hex D6   cycles  42   integ 100.80   60Hz cycles 6.05   50Hz cycles 5.04
+#define TCS34725_INTEGRATIONTIME_101MS (0xD6)/* 100.8ms - 42 cycles - Max Count: 43008 */
+// hex CE   cycles  50   integ 120.00   60Hz cycles 7.20   50Hz cycles 6.00
+#define TCS34725_INTEGRATIONTIME_120MS (0xCE)
+// hex C0   cycles  64   integ 153.60   60Hz cycles 9.22   50Hz cycles 7.68
 #define TCS34725_INTEGRATIONTIME_154MS (0xC0)/* 153.6ms - 64 cycles - Max Count: 65535 */
-#define TCS34725_INTEGRATIONTIME_615MS (0x00)/* 614.4ms - 256 cycles - Max Count: 65535 */
-#define TCS34725_INTEGRATIONTIME_700MS (0x00)/* WRONG BUT INCLUDED FOR LEGACY CODE */
+// hex B5   cycles  75   integ 180.00   60Hz cycles 10.80   50Hz cycles 9.00
+#define TCS34725_INTEGRATIONTIME_180MS (0xB5)
+// hex AD   cycles  83   integ 199.20   60Hz cycles 11.95   50Hz cycles 9.96
+#define TCS34725_INTEGRATIONTIME_154MS (0xAD)
+// hex 9C   cycles 100   integ 240.00   60Hz cycles 14.40   50Hz cycles 12.00
+#define TCS34725_INTEGRATIONTIME_240MS (0x9C)
+// hex 83   cycles 125   integ 300.00   60Hz cycles 18.00   50Hz cycles 15.00
+#define TCS34725_INTEGRATIONTIME_300MS (0x83)/* 300ms - 125 cycles - Max Count: 65535 */
+// hex 6A   cycles 150   integ 360.00   60Hz cycles 21.60   50Hz cycles 18.00
+#define TCS34725_INTEGRATIONTIME_360MS (0x6A)
+// hex 59   cycles 167   integ 400.80   60Hz cycles 24.05   50Hz cycles 20.04
+#define TCS34725_INTEGRATIONTIME_401MS (0x59)
+// hex 51   cycles 175   integ 420.00   60Hz cycles 25.20   50Hz cycles 21.00
+#define TCS34725_INTEGRATIONTIME_420MS (0x51)
+// hex 38   cycles 200   integ 480.00   60Hz cycles 28.80   50Hz cycles 24.00
+#define TCS34725_INTEGRATIONTIME_480MS (0x38)
+// hex 30   cycles 208   integ 499.20   60Hz cycles 29.95   50Hz cycles 24.96
+#define TCS34725_INTEGRATIONTIME_499MS (0x30)
+// hex 1F   cycles 225   integ 540.00   60Hz cycles 32.40   50Hz cycles 27.00
+#define TCS34725_INTEGRATIONTIME_540MS (0x1F)
+// hex 06   cycles 250   integ 600.00   60Hz cycles 36.00   50Hz cycles 30.00
+#define TCS34725_INTEGRATIONTIME_600MS (0x06)
+// hex 00   cycles 256   integ 614.40   60Hz cycles 36.86   50Hz cycles 30.72
+#define TCS34725_INTEGRATIONTIME_614MS (0x00)/* 614.4ms - 256 cycles - Max Count: 65535 */
 
 /** Gain settings for TCS34725  */
 typedef enum {

--- a/Adafruit_TCS34725.h
+++ b/Adafruit_TCS34725.h
@@ -138,44 +138,47 @@
 #define TCS34725_BDATAH (0x1B) /**< Blue channel data high byte */
 
 /** Integration time settings for TCS34725 */
-/* 100ms is evenly divisible by 50Hz periods and by 60Hz periods */
-// 2.4ms - 1 cycle - Max Count: 1024 - 60Hz cycles 0.14 - 50Hz cycles 0.12
-#define TCS34725_INTEGRATIONTIME_2_4MS (0xFF)
-// 24.0ms - 10 cycles - Max Count: 10240 - 60Hz cycles 1.44   50Hz cycles 1.20
-#define TCS34725_INTEGRATIONTIME_24MS (0xF6)
-// 50.4ms - 21 cycles - Max Count: ????? - 60Hz cycles 3.0 - 50Hz cycles 2.5
-#define TCS34725_INTEGRATIONTIME_50MS (0xEB)
-// 60.0ms - 25 cycles - Max Count: ????? - 60Hz cycles 3.6 - 50Hz cycles 3.0
-#define TCS34725_INTEGRATIONTIME_60MS (0xE7)
-// 100.8ms - 42 cycles - Max Count: 43008 - 60Hz cycles 6.1 - 50Hz cycles 5.0
-#define TCS34725_INTEGRATIONTIME_101MS (0xD6)
-// 120.0ms - 50 cycles - Max Count: ????? - 60Hz cycles 7.2 - 50Hz cycles 6.0
-#define TCS34725_INTEGRATIONTIME_120MS (0xCE)
-// 153.6ms - 64 cycles - Max Count: 65535 - 60Hz cycles 9.2 - 50Hz cycles 7.7
-#define TCS34725_INTEGRATIONTIME_154MS (0xC0)
-// 180.0ms - 75 cycles - Max Count: 65535 - 60Hz cycles 10.8 - 50Hz cycles 9.0
-#define TCS34725_INTEGRATIONTIME_180MS (0xB5)
-// 199.2ms - 83 cycles - Max Count: 65535 - 60Hz cycles 12.0 - 50Hz cycles 10.0
-#define TCS34725_INTEGRATIONTIME_199MS (0xAD)
-// 240.0ms - 100 cycles - Max Count: 65535 - 60Hz cycles 14.4 - 50Hz cycles 12.0
-#define TCS34725_INTEGRATIONTIME_240MS (0x9C)
-// 300.0ms - 125 cycles - Max Count: 65535 - 60Hz cycles 18.0 - 50Hz cycles 15.0
-#define TCS34725_INTEGRATIONTIME_300MS (0x83)
-// 360.0ms - 150 cycles - Max Count: 65535 - 60Hz cycles 21.6 - 50Hz cycles 18.0
-#define TCS34725_INTEGRATIONTIME_360MS (0x6A)
-#define TCS34725_INTEGRATIONTIME_401MS
+/*
+ * 60-Hz period: 16.67ms, 50-Hz period: 20ms
+ * 100ms is evenly divisible by 50Hz periods and by 60Hz periods
+ */
+#define TCS34725_INTEGRATIONTIME_2_4MS                                         \
+  (0xFF) /**< 2.4ms - 1 cycle - Max Count: 1024 */
+#define TCS34725_INTEGRATIONTIME_24MS                                          \
+  (0xF6) /**< 24.0ms - 10 cycles - Max Count: 10240 */
+#define TCS34725_INTEGRATIONTIME_50MS                                          \
+  (0xEB) /**< 50.4ms - 21 cycles - Max Count: 21504 */
+#define TCS34725_INTEGRATIONTIME_60MS                                          \
+  (0xE7) /**< 60.0ms - 25 cycles - Max Count: 25700 */
+#define TCS34725_INTEGRATIONTIME_101MS                                         \
+  (0xD6) /**< 100.8ms - 42 cycles - Max Count: 43008 */
+#define TCS34725_INTEGRATIONTIME_120MS                                         \
+  (0xCE) /**< 120.0ms - 50 cycles - Max Count: 51200 */
+#define TCS34725_INTEGRATIONTIME_154MS                                         \
+  (0xC0) /**< 153.6ms - 64 cycles - Max Count: 65535 */
+#define TCS34725_INTEGRATIONTIME_180MS                                         \
+  (0xB5) /**< 180.0ms - 75 cycles - Max Count: 65535 */
+#define TCS34725_INTEGRATIONTIME_199MS                                         \
+  (0xAD) /**< 199.2ms - 83 cycles - Max Count: 65535 */
+#define TCS34725_INTEGRATIONTIME_240MS                                         \
+  (0x9C) /**< 240.0ms - 100 cycles - Max Count: 65535 */
+#define TCS34725_INTEGRATIONTIME_300MS                                         \
+  (0x83) /**< 300.0ms - 125 cycles - Max Count: 65535 */
+#define TCS34725_INTEGRATIONTIME_360MS                                         \
+  (0x6A) /**< 360.0ms - 150 cycles - Max Count: 65535 */
+#define TCS34725_INTEGRATIONTIME_401MS                                         \
   (0x59) /**< 400.8ms - 167 cycles - Max Count: 65535 */
-#define TCS34725_INTEGRATIONTIME_420MS
+#define TCS34725_INTEGRATIONTIME_420MS                                         \
   (0x51) /**< 420.0ms - 175 cycles - Max Count: 65535 */
-#define TCS34725_INTEGRATIONTIME_480MS
+#define TCS34725_INTEGRATIONTIME_480MS                                         \
   (0x38) /**< 480.0ms - 200 cycles - Max Count: 65535 */
-#define TCS34725_INTEGRATIONTIME_499MS
+#define TCS34725_INTEGRATIONTIME_499MS                                         \
   (0x30) /**< 499.2ms - 208 cycles - Max Count: 65535 */
-#define TCS34725_INTEGRATIONTIME_540MS
+#define TCS34725_INTEGRATIONTIME_540MS                                         \
   (0x1F) /**< 540.0ms - 225 cycles - Max Count: 65535 */
-#define TCS34725_INTEGRATIONTIME_600MS
+#define TCS34725_INTEGRATIONTIME_600MS                                         \
   (0x06) /**< 600.0ms - 250 cycles - Max Count: 65535 */
-#define TCS34725_INTEGRATIONTIME_614MS
+#define TCS34725_INTEGRATIONTIME_614MS                                         \
   (0x00) /**< 614.4ms - 256 cycles - Max Count: 65535 */
 
 /** Gain settings for TCS34725  */

--- a/Adafruit_TCS34725.h
+++ b/Adafruit_TCS34725.h
@@ -138,24 +138,14 @@
 #define TCS34725_BDATAH (0x1B) /**< Blue channel data high byte */
 
 /** Integration time settings for TCS34725 */
-typedef enum {
-  TCS34725_INTEGRATIONTIME_2_4MS =
-      0xFF, /**<  2.4ms - 1 cycle    - Max Count: 1024  */
-  TCS34725_INTEGRATIONTIME_24MS =
-      0xF6, /**<  24ms  - 10 cycles  - Max Count: 10240 */
-  TCS34725_INTEGRATIONTIME_48MS =
-      0xEB, /**<  48ms  - 20 cycles  - Max Count: 20480 */
-  TCS34725_INTEGRATIONTIME_50MS =
-      0xEB, /**<  WRONG BUT INCLUDED FOR LEGACY CODE */
-  TCS34725_INTEGRATIONTIME_101MS =
-      0xD5, /**<  100.8ms - 42 cycles  - Max Count: 43008 */
-  TCS34725_INTEGRATIONTIME_154MS =
-      0xC0, /**<  153.6ms - 64 cycles  - Max Count: 65535 */
-  TCS34725_INTEGRATIONTIME_615MS =
-      0x00, /**<  614.4ms - 256 cycles - Max Count: 65535 */
-  TCS34725_INTEGRATIONTIME_700MS =
-      0x00 /**<  WRONG BUT INCLUDED FOR LEGACY CODE */
-} tcs34725IntegrationTime_t;
+#define TCS34725_INTEGRATIONTIME_2_4MS (0xFF)/* 2.4ms - 1 cycle - Max Count: 1024 */
+#define TCS34725_INTEGRATIONTIME_24MS (0xF6) /* 24ms - 10 cycles - Max Count: 10240 */
+#define TCS34725_INTEGRATIONTIME_48MS (0xEB) /* 48ms - 20 cycles - Max Count: 20480 */
+#define TCS34725_INTEGRATIONTIME_50MS (0xEB) /* WRONG BUT INCLUDED FOR LEGACY CODE */
+#define TCS34725_INTEGRATIONTIME_101MS (0xD5)/* 100.8ms - 42 cycles - Max Count: 43008 */
+#define TCS34725_INTEGRATIONTIME_154MS (0xC0)/* 153.6ms - 64 cycles - Max Count: 65535 */
+#define TCS34725_INTEGRATIONTIME_615MS (0x00)/* 614.4ms - 256 cycles - Max Count: 65535 */
+#define TCS34725_INTEGRATIONTIME_700MS (0x00)/* WRONG BUT INCLUDED FOR LEGACY CODE */
 
 /** Gain settings for TCS34725  */
 typedef enum {
@@ -171,7 +161,7 @@ typedef enum {
  */
 class Adafruit_TCS34725 {
 public:
-  Adafruit_TCS34725(tcs34725IntegrationTime_t = TCS34725_INTEGRATIONTIME_2_4MS,
+  Adafruit_TCS34725(uint8_t = TCS34725_INTEGRATIONTIME_2_4MS,
                     tcs34725Gain_t = TCS34725_GAIN_1X);
 
   boolean begin(uint8_t addr, TwoWire *theWire);
@@ -179,7 +169,7 @@ public:
   boolean begin();
   boolean init();
 
-  void setIntegrationTime(tcs34725IntegrationTime_t it);
+  void setIntegrationTime(uint8_t it);
   void setGain(tcs34725Gain_t gain);
   void getRawData(uint16_t *r, uint16_t *g, uint16_t *b, uint16_t *c);
   void getRGB(float *r, float *g, float *b);
@@ -202,7 +192,7 @@ private:
   uint8_t _i2caddr;
   boolean _tcs34725Initialised;
   tcs34725Gain_t _tcs34725Gain;
-  tcs34725IntegrationTime_t _tcs34725IntegrationTime;
+  uint8_t _tcs34725IntegrationTime;
 };
 
 #endif

--- a/Adafruit_TCS34725.h
+++ b/Adafruit_TCS34725.h
@@ -175,7 +175,7 @@
 #define TCS34725_INTEGRATIONTIME_540MS (0x1F)
 // 600.0ms - 250 cycles - Max Count: 65535 - 60Hz cycles 36.0 - 50Hz cycles 30.0
 #define TCS34725_INTEGRATIONTIME_600MS (0x06)
-// 614.4ms - 256 cycles - Max Count: 65535 - 60Hz cycles 36.9 - 50Hz cycles 30.7
+/**< 614.4ms - 256 cycles - Max Count: 65535 - 60Hz cycles 36.9 - 50Hz cycles 30.7 */
 #define TCS34725_INTEGRATIONTIME_614MS (0x00)
 
 /** Gain settings for TCS34725  */

--- a/Adafruit_TCS34725.h
+++ b/Adafruit_TCS34725.h
@@ -163,20 +163,20 @@
 #define TCS34725_INTEGRATIONTIME_300MS (0x83)
 // 360.0ms - 150 cycles - Max Count: 65535 - 60Hz cycles 21.6 - 50Hz cycles 18.0
 #define TCS34725_INTEGRATIONTIME_360MS (0x6A)
-// 400.8ms - 167 cycles - Max Count: 65535 - 60Hz cycles 24.1 - 50Hz cycles 20.0
-#define TCS34725_INTEGRATIONTIME_401MS (0x59)
-// 420.0ms - 175 cycles - Max Count: 65535 - 60Hz cycles 25.2 - 50Hz cycles 21.0
-#define TCS34725_INTEGRATIONTIME_420MS (0x51)
-// 480.0ms - 200 cycles - Max Count: 65535 - 60Hz cycles 28.8 - 50Hz cycles 24.0
-#define TCS34725_INTEGRATIONTIME_480MS (0x38)
-// 499.2ms - 208 cycles - Max Count: 65535 - 60Hz cycles 30.0   50Hz cycles 25.0
-#define TCS34725_INTEGRATIONTIME_499MS (0x30)
-// 540.0ms - 225 cycles - Max Count: 65535 - 60Hz cycles 32.4   50Hz cycles 27.0
-#define TCS34725_INTEGRATIONTIME_540MS (0x1F)
-// 600.0ms - 250 cycles - Max Count: 65535 - 60Hz cycles 36.0 - 50Hz cycles 30.0
-#define TCS34725_INTEGRATIONTIME_600MS (0x06)
-/**< 614.4ms - 256 cycles - Max Count: 65535 */
-#define TCS34725_INTEGRATIONTIME_614MS (0x00)
+#define TCS34725_INTEGRATIONTIME_401MS
+  (0x59) /**< 400.8ms - 167 cycles - Max Count: 65535 */
+#define TCS34725_INTEGRATIONTIME_420MS
+  (0x51) /**< 420.0ms - 175 cycles - Max Count: 65535 */
+#define TCS34725_INTEGRATIONTIME_480MS
+  (0x38) /**< 480.0ms - 200 cycles - Max Count: 65535 */
+#define TCS34725_INTEGRATIONTIME_499MS
+  (0x30) /**< 499.2ms - 208 cycles - Max Count: 65535 */
+#define TCS34725_INTEGRATIONTIME_540MS
+  (0x1F) /**< 540.0ms - 225 cycles - Max Count: 65535 */
+#define TCS34725_INTEGRATIONTIME_600MS
+  (0x06) /**< 600.0ms - 250 cycles - Max Count: 65535 */
+#define TCS34725_INTEGRATIONTIME_614MS
+  (0x00) /**< 614.4ms - 256 cycles - Max Count: 65535 */
 
 /** Gain settings for TCS34725  */
 typedef enum {

--- a/Adafruit_TCS34725.h
+++ b/Adafruit_TCS34725.h
@@ -175,7 +175,7 @@
 #define TCS34725_INTEGRATIONTIME_540MS (0x1F)
 // 600.0ms - 250 cycles - Max Count: 65535 - 60Hz cycles 36.0 - 50Hz cycles 30.0
 #define TCS34725_INTEGRATIONTIME_600MS (0x06)
-/**< 614.4ms - 256 cycles - Max Count: 65535 - 60Hz cycles 36.9 - 50Hz cycles 30.7 */
+/**< 614.4ms - 256 cycles - Max Count: 65535 */
 #define TCS34725_INTEGRATIONTIME_614MS (0x00)
 
 /** Gain settings for TCS34725  */

--- a/Adafruit_TCS34725.h
+++ b/Adafruit_TCS34725.h
@@ -143,14 +143,18 @@ typedef enum {
       0xFF, /**<  2.4ms - 1 cycle    - Max Count: 1024  */
   TCS34725_INTEGRATIONTIME_24MS =
       0xF6, /**<  24ms  - 10 cycles  - Max Count: 10240 */
+  TCS34725_INTEGRATIONTIME_48MS =
+      0xEB, /**<  48ms  - 20 cycles  - Max Count: 20480 */
   TCS34725_INTEGRATIONTIME_50MS =
-      0xEB, /**<  50ms  - 20 cycles  - Max Count: 20480 */
+      0xEB, /**<  WRONG BUT INCLUDED FOR LEGACY CODE */
   TCS34725_INTEGRATIONTIME_101MS =
-      0xD5, /**<  101ms - 42 cycles  - Max Count: 43008 */
+      0xD5, /**<  100.8ms - 42 cycles  - Max Count: 43008 */
   TCS34725_INTEGRATIONTIME_154MS =
-      0xC0, /**<  154ms - 64 cycles  - Max Count: 65535 */
+      0xC0, /**<  153.6ms - 64 cycles  - Max Count: 65535 */
+  TCS34725_INTEGRATIONTIME_615MS =
+      0x00, /**<  614.4ms - 256 cycles - Max Count: 65535 */
   TCS34725_INTEGRATIONTIME_700MS =
-      0x00 /**<  700ms - 256 cycles - Max Count: 65535 */
+      0x00 /**<  WRONG BUT INCLUDED FOR LEGACY CODE */
 } tcs34725IntegrationTime_t;
 
 /** Gain settings for TCS34725  */

--- a/Adafruit_TCS34725.h
+++ b/Adafruit_TCS34725.h
@@ -139,44 +139,44 @@
 
 /** Integration time settings for TCS34725 */
 /* 100ms is evenly divisible by 50Hz periods and by 60Hz periods */
-// hex FF   cycles   1   integ 2.40   60Hz cycles 0.14   50Hz cycles 0.12
-#define TCS34725_INTEGRATIONTIME_2_4MS (0xFF)/* 2.4ms - 1 cycle - Max Count: 1024 */
-// hex F6   cycles  10   integ 24.00   60Hz cycles 1.44   50Hz cycles 1.20
-#define TCS34725_INTEGRATIONTIME_24MS (0xF6) /* 24ms - 10 cycles - Max Count: 10240 */
-// hex EB   cycles  21   integ 50.40   60Hz cycles 3.02   50Hz cycles 2.52
-#define TCS34725_INTEGRATIONTIME_50MS (0xEB) /* 50.4ms - 21 cycles - Max Count: ???? */
-// hex E7   cycles  25   integ 60.00   60Hz cycles 3.60   50Hz cycles 3.00
+// 2.4ms - 1 cycle - Max Count: 1024 - 60Hz cycles 0.14 - 50Hz cycles 0.12
+#define TCS34725_INTEGRATIONTIME_2_4MS (0xFF)
+// 24.0ms - 10 cycles - Max Count: 10240 - 60Hz cycles 1.44   50Hz cycles 1.20
+#define TCS34725_INTEGRATIONTIME_24MS (0xF6)
+// 50.4ms - 21 cycles - Max Count: ????? - 60Hz cycles 3.0 - 50Hz cycles 2.5
+#define TCS34725_INTEGRATIONTIME_50MS (0xEB)
+// 60.0ms - 25 cycles - Max Count: ????? - 60Hz cycles 3.6 - 50Hz cycles 3.0
 #define TCS34725_INTEGRATIONTIME_60MS (0xE7)
-// hex D6   cycles  42   integ 100.80   60Hz cycles 6.05   50Hz cycles 5.04
-#define TCS34725_INTEGRATIONTIME_101MS (0xD6)/* 100.8ms - 42 cycles - Max Count: 43008 */
-// hex CE   cycles  50   integ 120.00   60Hz cycles 7.20   50Hz cycles 6.00
+// 100.8ms - 42 cycles - Max Count: 43008 - 60Hz cycles 6.1 - 50Hz cycles 5.0
+#define TCS34725_INTEGRATIONTIME_101MS (0xD6)
+// 120.0ms - 50 cycles - Max Count: ????? - 60Hz cycles 7.2 - 50Hz cycles 6.0
 #define TCS34725_INTEGRATIONTIME_120MS (0xCE)
-// hex C0   cycles  64   integ 153.60   60Hz cycles 9.22   50Hz cycles 7.68
-#define TCS34725_INTEGRATIONTIME_154MS (0xC0)/* 153.6ms - 64 cycles - Max Count: 65535 */
-// hex B5   cycles  75   integ 180.00   60Hz cycles 10.80   50Hz cycles 9.00
+// 153.6ms - 64 cycles - Max Count: 65535 - 60Hz cycles 9.2 - 50Hz cycles 7.7
+#define TCS34725_INTEGRATIONTIME_154MS (0xC0)
+// 180.0ms - 75 cycles - Max Count: 65535 - 60Hz cycles 10.8 - 50Hz cycles 9.0
 #define TCS34725_INTEGRATIONTIME_180MS (0xB5)
-// hex AD   cycles  83   integ 199.20   60Hz cycles 11.95   50Hz cycles 9.96
-#define TCS34725_INTEGRATIONTIME_154MS (0xAD)
-// hex 9C   cycles 100   integ 240.00   60Hz cycles 14.40   50Hz cycles 12.00
+// 199.2ms - 83 cycles - Max Count: 65535 - 60Hz cycles 12.0 - 50Hz cycles 10.0
+#define TCS34725_INTEGRATIONTIME_199MS (0xAD)
+// 240.0ms - 100 cycles - Max Count: 65535 - 60Hz cycles 14.4 - 50Hz cycles 12.0
 #define TCS34725_INTEGRATIONTIME_240MS (0x9C)
-// hex 83   cycles 125   integ 300.00   60Hz cycles 18.00   50Hz cycles 15.00
-#define TCS34725_INTEGRATIONTIME_300MS (0x83)/* 300ms - 125 cycles - Max Count: 65535 */
-// hex 6A   cycles 150   integ 360.00   60Hz cycles 21.60   50Hz cycles 18.00
+// 300.0ms - 125 cycles - Max Count: 65535 - 60Hz cycles 18.0 - 50Hz cycles 15.0
+#define TCS34725_INTEGRATIONTIME_300MS (0x83)
+// 360.0ms - 150 cycles - Max Count: 65535 - 60Hz cycles 21.6 - 50Hz cycles 18.0
 #define TCS34725_INTEGRATIONTIME_360MS (0x6A)
-// hex 59   cycles 167   integ 400.80   60Hz cycles 24.05   50Hz cycles 20.04
+// 400.8ms - 167 cycles - Max Count: 65535 - 60Hz cycles 24.1 - 50Hz cycles 20.0
 #define TCS34725_INTEGRATIONTIME_401MS (0x59)
-// hex 51   cycles 175   integ 420.00   60Hz cycles 25.20   50Hz cycles 21.00
+// 420.0ms - 175 cycles - Max Count: 65535 - 60Hz cycles 25.2 - 50Hz cycles 21.0
 #define TCS34725_INTEGRATIONTIME_420MS (0x51)
-// hex 38   cycles 200   integ 480.00   60Hz cycles 28.80   50Hz cycles 24.00
+// 480.0ms - 200 cycles - Max Count: 65535 - 60Hz cycles 28.8 - 50Hz cycles 24.0
 #define TCS34725_INTEGRATIONTIME_480MS (0x38)
-// hex 30   cycles 208   integ 499.20   60Hz cycles 29.95   50Hz cycles 24.96
+// 499.2ms - 208 cycles - Max Count: 65535 - 60Hz cycles 30.0   50Hz cycles 25.0
 #define TCS34725_INTEGRATIONTIME_499MS (0x30)
-// hex 1F   cycles 225   integ 540.00   60Hz cycles 32.40   50Hz cycles 27.00
+// 540.0ms - 225 cycles - Max Count: 65535 - 60Hz cycles 32.4   50Hz cycles 27.0
 #define TCS34725_INTEGRATIONTIME_540MS (0x1F)
-// hex 06   cycles 250   integ 600.00   60Hz cycles 36.00   50Hz cycles 30.00
+// 600.0ms - 250 cycles - Max Count: 65535 - 60Hz cycles 36.0 - 50Hz cycles 30.0
 #define TCS34725_INTEGRATIONTIME_600MS (0x06)
-// hex 00   cycles 256   integ 614.40   60Hz cycles 36.86   50Hz cycles 30.72
-#define TCS34725_INTEGRATIONTIME_614MS (0x00)/* 614.4ms - 256 cycles - Max Count: 65535 */
+// 614.4ms - 256 cycles - Max Count: 65535 - 60Hz cycles 36.9 - 50Hz cycles 30.7
+#define TCS34725_INTEGRATIONTIME_614MS (0x00)
 
 /** Gain settings for TCS34725  */
 typedef enum {

--- a/examples/integration_time/integration_time.ino
+++ b/examples/integration_time/integration_time.ino
@@ -1,0 +1,65 @@
+#include <Wire.h>
+#include "Adafruit_TCS34725.h"
+
+/* Example code for the Adafruit TCS34725 breakout library */
+
+/* Connect SCL    to analog 5
+   Connect SDA    to analog 4
+   Connect VDD    to 3.3V DC
+   Connect GROUND to common ground */
+
+/* Initialise with default values (int time = 2.4ms, gain = 1x) */
+// Adafruit_TCS34725 tcs = Adafruit_TCS34725();
+
+/* Initialise with specific int time and gain values */
+Adafruit_TCS34725 tcs = Adafruit_TCS34725(TCS34725_INTEGRATIONTIME_614MS, TCS34725_GAIN_1X);
+
+void setup(void) {
+  Serial.begin(9600);
+
+  if (tcs.begin()) {
+    Serial.println("Found sensor");
+  } else {
+    Serial.println("No TCS34725 found ... check your connections");
+    while (1);
+  }
+
+  // Now we're ready to get readings!
+}
+
+void loop(void) {
+  uint16_t r, g, b, c, colorTemp, lux;
+
+  tcs.setIntegrationTime(TCS34725_INTEGRATIONTIME_614MS);
+  delay(154); // Delay for one old integ. time period (to finish old reading)
+  delay(615); // Delay for one new integ. time period (to allow new reading)
+  tcs.getRawData(&r, &g, &b, &c);
+  Serial.print("Integ. time: 614.4ms ");
+  Serial.print("R: "); Serial.print(r, DEC); Serial.print(" ");
+  Serial.print("G: "); Serial.print(g, DEC); Serial.print(" ");
+  Serial.print("B: "); Serial.print(b, DEC); Serial.print(" ");
+  Serial.print("C: "); Serial.print(c, DEC); Serial.print(" ");
+  Serial.println(" ");
+
+  tcs.setIntegrationTime(TCS34725_INTEGRATIONTIME_300MS);
+  delay(615); // Delay for one old integ. time period (to finish old reading)
+  delay(300); // Delay for one new integ. time period (to allow new reading)
+  tcs.getRawData(&r, &g, &b, &c);
+  Serial.print("Integ. time: 300.0ms ");
+  Serial.print("R: "); Serial.print(r, DEC); Serial.print(" ");
+  Serial.print("G: "); Serial.print(g, DEC); Serial.print(" ");
+  Serial.print("B: "); Serial.print(b, DEC); Serial.print(" ");
+  Serial.print("C: "); Serial.print(c, DEC); Serial.print(" ");
+  Serial.println(" ");
+
+  tcs.setIntegrationTime(TCS34725_INTEGRATIONTIME_154MS);
+  delay(300); // Delay for one old integ. time period (to finish old reading)
+  delay(154); // Delay for one new integ. time period (to allow new reading)
+  tcs.getRawData(&r, &g, &b, &c);
+  Serial.print("Integ. time: 153.6ms ");
+  Serial.print("R: "); Serial.print(r, DEC); Serial.print(" ");
+  Serial.print("G: "); Serial.print(g, DEC); Serial.print(" ");
+  Serial.print("B: "); Serial.print(b, DEC); Serial.print(" ");
+  Serial.print("C: "); Serial.print(c, DEC); Serial.print(" ");
+  Serial.println(" ");
+}

--- a/examples/interrupt/interrupt.ino
+++ b/examples/interrupt/interrupt.ino
@@ -3,7 +3,7 @@
 
 
 /* Initialise with specific int time and gain values */
-Adafruit_TCS34725 tcs = Adafruit_TCS34725(TCS34725_INTEGRATIONTIME_700MS, TCS34725_GAIN_1X);
+Adafruit_TCS34725 tcs = Adafruit_TCS34725(TCS34725_INTEGRATIONTIME_614MS, TCS34725_GAIN_1X);
 const int interruptPin = 2;
 volatile boolean state = false;
 

--- a/examples/tcs34725/tcs34725.ino
+++ b/examples/tcs34725/tcs34725.ino
@@ -12,7 +12,7 @@
 // Adafruit_TCS34725 tcs = Adafruit_TCS34725();
 
 /* Initialise with specific int time and gain values */
-Adafruit_TCS34725 tcs = Adafruit_TCS34725(TCS34725_INTEGRATIONTIME_700MS, TCS34725_GAIN_1X);
+Adafruit_TCS34725 tcs = Adafruit_TCS34725(TCS34725_INTEGRATIONTIME_614MS, TCS34725_GAIN_1X);
 
 void setup(void) {
   Serial.begin(9600);

--- a/examples/tcs34725autorange/tcs34725autorange.ino
+++ b/examples/tcs34725autorange/tcs34725autorange.ino
@@ -39,7 +39,7 @@ class tcs34725 {
 private:
   struct tcs_agc {
     tcs34725Gain_t ag;
-    tcs34725IntegrationTime_t at;
+    uint8_t at;
     uint16_t mincnt;
     uint16_t maxcnt;
   };
@@ -71,7 +71,7 @@ public:
 // the start and end of the list.
 //
 const tcs34725::tcs_agc tcs34725::agc_lst[] = {
-  { TCS34725_GAIN_60X, TCS34725_INTEGRATIONTIME_700MS,     0, 20000 },
+  { TCS34725_GAIN_60X, TCS34725_INTEGRATIONTIME_614MS,     0, 20000 },
   { TCS34725_GAIN_60X, TCS34725_INTEGRATIONTIME_154MS,  4990, 63000 },
   { TCS34725_GAIN_16X, TCS34725_INTEGRATIONTIME_154MS, 16790, 63000 },
   { TCS34725_GAIN_4X,  TCS34725_INTEGRATIONTIME_154MS, 15740, 63000 },


### PR DESCRIPTION
Some of the enum's for setting ATIME (names `TCS34725_INTEGRATIONTIME_*MS` for `tcs34725IntegrationTime_t`) had the wrong integration times listed.  
* added some enum names that include the proper integration times
* kept the old enum names as duplicate names for the same values, even though their listed time didn't match the actual integration time, in order not to break legacy code.
* fixed the delays in the case statements in ` Adafruit_TCS34725.cpp` to match the (rounded-up) actual integration times.  This has the benefits of waiting the appropriate amount of time (not too long as before.)   e.g. it used to delay 700ms for a 614.4ms integration.

Note that the datasheet in Table 6 incorrectly lists 700ms as the integration time for ATIME=0, even though this disagrees with the integration time formula in the datasheet section "RGBC Operation".  I alerted AMS to the error and they agreed this was an error and replied that it would be fixed in the next version of the datasheet.