### PR TITLE
Use computed delay instead of case-switch

### DIFF
--- a/Adafruit_TCS34725.cpp
+++ b/Adafruit_TCS34725.cpp
@@ -126,7 +126,7 @@ void Adafruit_TCS34725::enable() {
     performed too quickly, the data is not yet valid and all 0's are
     returned */
   /* 12/5 = 2.4, add 1 to account for integer truncation */
-  delay((256 - _tcs34725IntegrationTime)*12/5 + 1);
+  delay((256 - _tcs34725IntegrationTime)* 12 / 5 + 1);
 }
 
 /*!
@@ -271,7 +271,7 @@ void Adafruit_TCS34725::getRawData(uint16_t *r, uint16_t *g, uint16_t *b,
 
   /* Set a delay for the integration time */
   /* 12/5 = 2.4, add 1 to account for integer truncation */
-  delay((256 - _tcs34725IntegrationTime)*12/5 + 1);
+  delay((256 - _tcs34725IntegrationTime) * 12 / 5 + 1);
 }
 
 /*!

--- a/Adafruit_TCS34725.cpp
+++ b/Adafruit_TCS34725.cpp
@@ -126,7 +126,7 @@ void Adafruit_TCS34725::enable() {
     performed too quickly, the data is not yet valid and all 0's are
     returned */
   /* 12/5 = 2.4, add 1 to account for integer truncation */
-  delay((256 - _tcs34725IntegrationTime)* 12 / 5 + 1);
+  delay((256 - _tcs34725IntegrationTime) * 12 / 5 + 1);
 }
 
 /*!

--- a/Adafruit_TCS34725.cpp
+++ b/Adafruit_TCS34725.cpp
@@ -125,26 +125,8 @@ void Adafruit_TCS34725::enable() {
     AEN triggers an automatic integration, so if a read RGBC is
     performed too quickly, the data is not yet valid and all 0's are
     returned */
-  switch (_tcs34725IntegrationTime) {
-  case TCS34725_INTEGRATIONTIME_2_4MS:
-    delay(3);
-    break;
-  case TCS34725_INTEGRATIONTIME_24MS:
-    delay(24);
-    break;
-  case TCS34725_INTEGRATIONTIME_50MS:
-    delay(50);
-    break;
-  case TCS34725_INTEGRATIONTIME_101MS:
-    delay(101);
-    break;
-  case TCS34725_INTEGRATIONTIME_154MS:
-    delay(154);
-    break;
-  case TCS34725_INTEGRATIONTIME_700MS:
-    delay(700);
-    break;
-  }
+  /* 12/5 = 2.4, add 1 to account for integer truncation */
+  delay((256 - _tcs34725IntegrationTime)*12/5 + 1);
 }
 
 /*!
@@ -288,26 +270,8 @@ void Adafruit_TCS34725::getRawData(uint16_t *r, uint16_t *g, uint16_t *b,
   *b = read16(TCS34725_BDATAL);
 
   /* Set a delay for the integration time */
-  switch (_tcs34725IntegrationTime) {
-  case TCS34725_INTEGRATIONTIME_2_4MS:
-    delay(3);
-    break;
-  case TCS34725_INTEGRATIONTIME_24MS:
-    delay(24);
-    break;
-  case TCS34725_INTEGRATIONTIME_50MS:
-    delay(50);
-    break;
-  case TCS34725_INTEGRATIONTIME_101MS:
-    delay(101);
-    break;
-  case TCS34725_INTEGRATIONTIME_154MS:
-    delay(154);
-    break;
-  case TCS34725_INTEGRATIONTIME_700MS:
-    delay(700);
-    break;
-  }
+  /* 12/5 = 2.4, add 1 to account for integer truncation */
+  delay((256 - _tcs34725IntegrationTime)*12/5 + 1);
 }
 
 /*!


### PR DESCRIPTION
This replaces the case-switch statement for creating an integration time delay with a computed delay using efficient integer math.  It allows any arbitrary value of ATIME (and hence `_tcs34725IntegrationTime`) to be used.   

Literal ints use at least 16-bits on Arduino so the computation will not suffer from overflow errors.  As a side benefit, it uses 126 less bytes of program storage space.

The old version would add **no delay** if integration time was set to any other value than the enumerated ones.  This would result in the same measurement being read multiple times, an error.

This version gives much more flexibility for setting integration times and still be functional.