### PR TITLE
More accurate control of integration time

### DIFF
--- a/Adafruit_TCS34725.cpp
+++ b/Adafruit_TCS34725.cpp
@@ -222,17 +222,17 @@ boolean Adafruit_TCS34725::init() {
 /*!
  *  @brief  Sets the integration time for the TC34725
  *  @param  it_sec
- *          Desired integration time in seconds
- *  @return Actual integration time in seconds
+ *          Desired integration time in milliseconds
+ *  @return Actual integration time in milliseconds
  */
-float Adafruit_TCS34725::setIntegrationTimeMsec(float it_sec) {
+float Adafruit_TCS34725::setIntegrationTimeMsec(float it_msec) {
   if (!_tcs34725Initialised)
     begin();
 
-  tcs34725IntegrationTime_t atime = calculateIntegrationConstant(it_sec);
+  tcs34725IntegrationTime_t atime = calculateIntegrationConstant(it_msec);
   setIntegrationTime(atime);
-  float actual_it_sec = calculateIntegrationTime(atime);
-  return actual_it_sec;
+  float actual_it_msec = calculateIntegrationTime(atime);
+  return actual_it_msec;
 }
 
 /*!
@@ -314,6 +314,14 @@ void Adafruit_TCS34725::getRawData(uint16_t *r, uint16_t *g, uint16_t *b,
   *r = read16(TCS34725_RDATAL);
   *g = read16(TCS34725_GDATAL);
   *b = read16(TCS34725_BDATAL);
+}
+
+/*!
+ *  @brief  Returns the maximum value that could be reported by getRawData,
+ *          given the currently set integration time
+ */
+uint16_t Adafruit_TCS34725::getRawDataMax() {
+    return ((int)256 - (int)_tcs34725IntegrationTime) * 1024;
 }
 
 /*!

--- a/Adafruit_TCS34725.cpp
+++ b/Adafruit_TCS34725.cpp
@@ -321,7 +321,9 @@ void Adafruit_TCS34725::getRawData(uint16_t *r, uint16_t *g, uint16_t *b,
  *          given the currently set integration time
  */
 uint16_t Adafruit_TCS34725::getRawDataMax() {
-    return ((int)256 - (int)_tcs34725IntegrationTime) * 1024;
+    long mx = ((long)256 - (long)_tcs34725IntegrationTime) * 1024;
+    mx = mx > 65535 ? 65535 : mx;
+    return (uint16_t) mx;
 }
 
 /*!

--- a/Adafruit_TCS34725.h
+++ b/Adafruit_TCS34725.h
@@ -175,15 +175,19 @@ public:
   boolean begin();
   boolean init();
 
+  float setIntegrationTimeMsec(float it_msec);
   void setIntegrationTime(tcs34725IntegrationTime_t it);
+  void setIntegrationTime(uint8_t it);
   void setGain(tcs34725Gain_t gain);
-  void getRawData(uint16_t *r, uint16_t *g, uint16_t *b, uint16_t *c);
+  void getRawData(uint16_t *r, uint16_t *g, uint16_t *b, uint16_t *c, bool delay=true);
   void getRGB(float *r, float *g, float *b);
   void getRawDataOneShot(uint16_t *r, uint16_t *g, uint16_t *b, uint16_t *c);
   uint16_t calculateColorTemperature(uint16_t r, uint16_t g, uint16_t b);
   uint16_t calculateColorTemperature_dn40(uint16_t r, uint16_t g, uint16_t b,
                                           uint16_t c);
   uint16_t calculateLux(uint16_t r, uint16_t g, uint16_t b);
+  uint8_t calculateIntegrationConstant(float it_msec);
+  float calculateIntegrationTime(uint8_t it);
   void write8(uint8_t reg, uint32_t value);
   uint8_t read8(uint8_t reg);
   uint16_t read16(uint8_t reg);

--- a/Adafruit_TCS34725.h
+++ b/Adafruit_TCS34725.h
@@ -176,10 +176,10 @@ public:
   boolean init();
 
   float setIntegrationTimeMsec(float it_msec);
-  void setIntegrationTime(tcs34725IntegrationTime_t it);
   void setIntegrationTime(uint8_t it);
+  void setIntegrationTime(tcs34725IntegrationTime_t it);
   void setGain(tcs34725Gain_t gain);
-  void getRawData(uint16_t *r, uint16_t *g, uint16_t *b, uint16_t *c, bool delay=true);
+  void getRawData(uint16_t *r, uint16_t *g, uint16_t *b, uint16_t *c, bool wait=true);
   void getRGB(float *r, float *g, float *b);
   void getRawDataOneShot(uint16_t *r, uint16_t *g, uint16_t *b, uint16_t *c);
   uint16_t calculateColorTemperature(uint16_t r, uint16_t g, uint16_t b);
@@ -187,7 +187,7 @@ public:
                                           uint16_t c);
   uint16_t calculateLux(uint16_t r, uint16_t g, uint16_t b);
   uint8_t calculateIntegrationConstant(float it_msec);
-  float calculateIntegrationTime(uint8_t it);
+  float calculateIntegrationTime(uint8_t atime);
   void write8(uint8_t reg, uint32_t value);
   uint8_t read8(uint8_t reg);
   uint16_t read16(uint8_t reg);
@@ -196,13 +196,14 @@ public:
   void setIntLimits(uint16_t l, uint16_t h);
   void enable();
   void disable();
+  void reset();
 
 private:
   TwoWire *_wire;
   uint8_t _i2caddr;
   boolean _tcs34725Initialised;
   tcs34725Gain_t _tcs34725Gain;
-  tcs34725IntegrationTime_t _tcs34725IntegrationTime;
+  uint8_t _tcs34725IntegrationTime;
 };
 
 #endif

--- a/Adafruit_TCS34725.h
+++ b/Adafruit_TCS34725.h
@@ -180,6 +180,7 @@ public:
   void setIntegrationTime(tcs34725IntegrationTime_t it);
   void setGain(tcs34725Gain_t gain);
   void getRawData(uint16_t *r, uint16_t *g, uint16_t *b, uint16_t *c, bool wait=true);
+  uint16_t getRawDataMax();
   void getRGB(float *r, float *g, float *b);
   void getRawDataOneShot(uint16_t *r, uint16_t *g, uint16_t *b, uint16_t *c);
   uint16_t calculateColorTemperature(uint16_t r, uint16_t g, uint16_t b);


### PR DESCRIPTION
The changes here are all related to my attempts to achieve more reliable readings from the TCS43725, particularly when dealing with changes in integration time. The initial problem I ran into is that getRawData was returning values that were not consistent with the configured integration time (also reported in #15). After digging into that issue, I found that the implementation of `setIntegrationTime` wasn't consistent with the model described in the datasheet (also reported in #37). These two issues are addressed across several changes:

- Adds a boolean `wait` argument to `getRawData`, allowing to delay until integration has finished. (fixes #15).
- Adds `reset()` and calls this whenever changing integration time in order to begin the new integration immediately. This ensures that the delay in getRawData is sufficiently long to guarantee integration has completed.
- Removes delay from `enable()`; this is no longer necessary due to the above changes.
- Adds an override for `setIntegrationTime` that accepts a `uint8` argument rather than `tcs34725IntegrationTime_t`. The datasheet specifies that any value 0-255 is acceptable here, whereas `tcs34725IntegrationTime_t` only provides access to a few specific values.
- Adds `setIntegrationTimeMsec`, which selects the closest ATIME value to the requested duration and returns the actual integration time.
- Adds `getRawDataMax()`, which returns the maximum possible raw data value given the current integration time, making it possible to detect saturation.
- Adds `calculateIntegrationTime` and calculateIntegrationConstant`, which map back and forth between ATIME and integration time in msec. Note--the values I use here are based on my own measurements from my device, which did not match the values in the datasheet. I don't know whether these values will be universally accurate.

I believe these changes are backward compatible, with the exception of some timing differences and the addition of a reset() when setting integration time. I have tested both `examples/tcs34725` and `examples/tcs34725autorange`; everything seems ok there. The other two examples would have required some hardware modifications, though, so I haven't tried those.