### PR TITLE
Add support for TCS34727 (device ID 0x4d)

### DIFF
--- a/Adafruit_TCS34725.cpp
+++ b/Adafruit_TCS34725.cpp
@@ -219,7 +219,7 @@ boolean Adafruit_TCS34725::init() {
 
   /* Make sure we're actually connected */
   uint8_t x = read8(TCS34725_ID);
-  if ((x != 0x44) && (x != 0x10)) {
+  if ((x != 0x4d) && (x != 0x44) && (x != 0x10)) {
     return false;
   }
   _tcs34725Initialised = true;

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit TCS34725
-version=1.3.3
+version=1.3.4
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Driver for Adafruit's TCS34725 RGB Color Sensor Breakout


### PR DESCRIPTION
The new device TCS34727 returns ID of `0x4d` (by PDF table in page 27)

Part number | ID
-- | --
TCS34725 | 0x44
TCS34727 | 0x4D

Pass example tests with my new sensor :+1:
