### PR TITLE
Add CMakeLists.txt to use as ESP-IDF component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "Adafruit_TCS34725.cpp"
+                    INCLUDE_DIRS "."
+                    REQUIRES Arduino Adafruit_BusIO)


### PR DESCRIPTION
No code was changed. I only added a new simple file to help make using the library directly with ESP-IDF faster. It's a fairly basic update, but it may help speed up work for someone!
